### PR TITLE
fix: centcom cargo express circuit

### DIFF
--- a/modularmint/centcom/code/centcom_cargo.dm
+++ b/modularmint/centcom/code/centcom_cargo.dm
@@ -8,7 +8,7 @@
 	desc = "This console allows the user to purchase a package \
 		with 1/40th of the delivery time: made possible by Nanotrasen's new \"1500mm Orbital Railgun\".\
 		All sales are near instantaneous - please choose carefully"
-	circuit = /obj/item/circuitboard/computer/cargo/express
+	circuit = /obj/item/circuitboard/computer/cargo/express/centcom
 	req_access = list(ACCESS_CENT_GENERAL)
 	cargo_account = ACCOUNT_NT
 	contraband = FALSE


### PR DESCRIPTION
## About The Pull Request
Цкшная карго экспресс консоль при разборке теперь не становится обычной карго консолью


## Changelog

:cl:
fix: centcom cargo express console no longer drop up station express circuit during disassembly
/:cl: