### PR TITLE
fix: circuit_imprinter in centcom cargo

### DIFF
--- a/modularmint/centcom/code/cargo/general.dm
+++ b/modularmint/centcom/code/cargo/general.dm
@@ -141,7 +141,7 @@
 	cost = 5000
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/security)
 
-/datum/supply_pack/centcom/limited/protolathe_security
+/datum/supply_pack/centcom/limited/circuit_imprinter
 	name = "Circuit Imprinter"
 	desc = "Circuit Imprinter circuitboard."
 	cost = 5000


### PR DESCRIPTION
## About The Pull Request

Принтер плат теперь не пытается перезаписывать протолат сб(строка 138)

## Changelog

:cl:
fix: circuit_imprinter no longer override security protolathe in centcom cargo console
/:cl: